### PR TITLE
feat: install ssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update && \
     fonts-ipaexfont \
     fonts-noto-cjk \
     fonts-noto-cjk-extra \
-    fonts-texgyre && \
+    fonts-texgyre \
+    ssh-client && \
     # Install perl
     echo 'y' | cpan Unicode::GCString && \
     # Install pygments for minted


### PR DESCRIPTION
Adding ssh_client.

ssh is required when pushing the repository from VS Code to GitHub or other platforms.